### PR TITLE
Delete VCL.Menus from uses(it is not used in project)

### DIFF
--- a/Winapi.Hooks.pas
+++ b/Winapi.Hooks.pas
@@ -290,7 +290,9 @@ type
 implementation
 
 uses
-  System.SysUtils, VCL.Menus;
+  System.SysUtils
+//  , VCL.Menus
+  ;
 
 { TLowLevelMouseHook }
 


### PR DESCRIPTION
Very great lib!
Library works in FireMonkey Windows aps(tested)!